### PR TITLE
Some minor fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "small-pir"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.89.0"
 
 [dependencies]
 rand_chacha = "0.3"

--- a/bench.sh
+++ b/bench.sh
@@ -21,5 +21,5 @@ configs=(
 #    final_256mb_q56_t_comm
 
 for config in ${configs[@]}; do
-    cargo test --release -- --nocapture $config >& $config.out
+    cargo test --release -- --nocapture --include-ignored $config >& $config.out
 done

--- a/bench_1gb.sh
+++ b/bench_1gb.sh
@@ -22,5 +22,5 @@ configs=(
 #    final_1gb_q56_t_comm
 
 for config in ${configs[@]}; do
-    cargo test --release -- --nocapture $config >& $config.out
+    cargo test --release -- --nocapture --include-ignored $config >& $config.out
 done

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-02-07"
+channel = "nightly"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(target_feature = "avx512f", feature(stdarch_x86_avx512))]
 #![feature(array_chunks)]
 
 pub mod field;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1061,7 +1061,7 @@ mod tests {
     #[cfg(target_feature = "avx2")]
     #[test]
     fn test_mul_accum_horiz_deferred_avx2() {
-        test_mul_accum_horiz(mul_accum_horiz_deferred_avx2);
+        test_mul_accum_horiz(mul_accum_horiz_deferred_avx2::<Q>);
     }
 
     fn test_inner_prod<


### PR DESCRIPTION
1. Update the rust version in Cargo.toml (not necessary, but harmless)
2. Move to any rust nightly, now that the only feature needed is `array_chunks`
3. Allow the benches to run ignored tests
4. Add a missing parameter
5. Remove the feature flag for the released stdarch_x86_avx512 feature

I can report for final_256mb_q56_compute a seemingly acceptable result:

```
Total time for server to answer query: 111.426139ms
Total query time for all slices, excluding unpacking: 113.717181ms
Total query time for all slices, including unpacking: 212.204621ms
BFV query throughput: 28.1 GiB/s
GSW query throughput: 146.2 MiB/s
Normalized GSW query throughput (ell_gsw = 2): 292.5 MiB/s
```

I was not able to run tests.  I'm getting a stack overflow error.